### PR TITLE
Fix bug: readScalarData returns wrong value

### DIFF
--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -1233,7 +1233,7 @@ value = readScalarData(data_id, vertex_id)
 ```
 """
 function readScalarData(dataID::Integer, valueIndex::Integer)
-    dataValue = Float64(0.0)
+    dataValue = [Float64(0.0)]
     ccall(
         (:precicec_readScalarData, "libprecice"),
         Cvoid,
@@ -1242,7 +1242,7 @@ function readScalarData(dataID::Integer, valueIndex::Integer)
         valueIndex,
         dataValue,
     )
-    return dataValue
+    return dataValue[1]
 end
 
 


### PR DESCRIPTION
Closes #34 
In the current Bindings, the readScalarValue Function returns the wrong value.
There is a Variable `dataValue` that is initialized as `0.0` and then supposed to be passed by reference to C bindings of Julia. However, the passing via reference doesn't work. At some point the Value gets copied and `dataValue` still has the value it's initialized as. 

A fix for this is initializing `dataValue` as a scalar vector of a float. This prevents a copy of the value and the value that gets returned is correct.