### PR TITLE
Fix two bugs

### DIFF
--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -586,8 +586,7 @@ function getMeshVertices(meshID::Integer, ids::AbstractArray{Cint})
         ids,
         positions,
     )
-    return_positions = similar(positions, _size, getDimensions())
-    return permutedims(return_positions, reshape(positions, (_size, getDimensions())))
+    return permutedims(reshape(positions, (getDimensions(), _size)))
 end
 
 
@@ -1127,7 +1126,7 @@ function readBlockVectorData(dataID::Integer, valueIndices::AbstractArray{Cint})
         valueIndices,
         values,
     )
-    return permutedims(reshape(values, (_size, getDimensions())))
+    return permutedims(reshape(values, (getDimensions(), _size)))
 end
 
 @doc """


### PR DESCRIPTION
This PR fixes two bugs regarding `getMeshVertices` and `readBlockVectorData`.
In `readBlockVectorData` `reshape` was inverted so the resulting data is in the correct form
In `getMeshVetices` the call to [`permutedims`](https://docs.julialang.org/en/v1/base/arrays/#Base.permutedims) was wrong, as it takes an array and dimensions as an input, but in the bindings, the input were two different arrays