### PR TITLE
Remove meshName from arguments

### DIFF
--- a/solverdummy/README.md
+++ b/solverdummy/README.md
@@ -2,13 +2,13 @@ This is a minimal working example for using preCICEC.jl with Julia. The solverdu
 
 From this directory, run 
 ```
-julia ./solverdummy.jl ./precice-config.xml SolverOne MeshOne
+julia ./solverdummy.jl ./precice-config.xml SolverOne
 ```
 
 or 
 
 ```
-julia ./solverdummy.jl ./precice-config.xml SolverTwo MeshTwo
+julia ./solverdummy.jl ./precice-config.xml SolverTwo
 ```
 
 respectively.

--- a/solverdummy/solverdummy.jl
+++ b/solverdummy/solverdummy.jl
@@ -3,9 +3,9 @@ using PreCICE
 commRank = 0
 commSize = 1
 
-if size(ARGS, 1) < 2
-    println(
-        "ERROR: pass config path, solver name and mesh name, example: julia solverdummy.jl ./precice-config.xml SolverOne MeshOne",
+if size(ARGS, 1) < 1
+    @error(
+        "ERROR: pass config path and solver name, example: julia solverdummy.jl ./precice-config.xml SolverOne",
     )
     exit(1)
 end

--- a/test/test_solverdummy.jl
+++ b/test/test_solverdummy.jl
@@ -11,12 +11,12 @@ function test_solverdummy()
         path = "$(Sys.BINDIR)/julia"
         t = @task begin
             run(
-                `$path ../solverdummy/solverdummy.jl ../solverdummy/precice-config.xml SolverOne  MeshOne`,
+                `$path ../solverdummy/solverdummy.jl ../solverdummy/precice-config.xml SolverOne`,
             )
         end
         s = @task begin
             run(
-                `$path ../solverdummy/solverdummy.jl ../solverdummy/precice-config.xml SolverTwo  MeshTwo`,
+                `$path ../solverdummy/solverdummy.jl ../solverdummy/precice-config.xml SolverTwo`,
             )
         end
         schedule(t)
@@ -25,7 +25,7 @@ function test_solverdummy()
         wait(s)
 
         # cleanup
-        rm("precice-run/", recursive = true)
+        rm("precice-run/", recursive=true)
         files = readdir()
         for file in files
             if (endswith(file, "json") || endswith(file, "log"))

--- a/test/test_solverdummy.jl
+++ b/test/test_solverdummy.jl
@@ -25,7 +25,7 @@ function test_solverdummy()
         wait(s)
 
         # cleanup
-        rm("precice-run/", recursive=true)
+        rm("precice-run/", recursive = true)
         files = readdir()
         for file in files
             if (endswith(file, "json") || endswith(file, "log"))


### PR DESCRIPTION
The mesh name was removed from the input arguments to the other solverdummies in https://github.com/precice/precice/pull/1256. The change is now incorporated in the solverdummy in this repository for consistency.