### PR TITLE
Fix tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,8 +25,6 @@ push!(Libc.Libdl.DL_LOAD_PATH, dirname(abspath(PROGRAM_FILE)))
             And then test PreCICE again
             """)
         else
-            # push!(Libc.Libdl.DL_LOAD_PATH, "$(dirname(abspath(PROGRAM_FILE)))")
-
             include("test_functioncalls.jl")
             @test constructor()
             @test version()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ push!(Libc.Libdl.DL_LOAD_PATH, dirname(abspath(PROGRAM_FILE)))
     end
 
     @testset "Function calls" begin
-        if !isfile(join(dirname(abspath(PROGRAM_FILE)), "libprecice.so"))
+        if !isfile(joinpath(dirname(abspath(PROGRAM_FILE)), "libprecice.so"))
             @info("""
             To run the function tests, please run:
             ``` 


### PR DESCRIPTION
Error in the tests so it only ran 2 out of 22 tests. This was caused by having `join` instead of `joinpath` to connect two paths, which resulted in the if statement always returning `true`