### PR TITLE
Use precice develop for tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}     
        
-      - uses: precice/setup-precice-action@testing
-        with:
-          precice-version: 'develop'
+      # - uses: precice/setup-precice-action@testing
+      #   with:
+      #     precice-version: 'develop'
 
       - uses: actions/checkout@v2
 
@@ -26,7 +26,6 @@ jobs:
 
   run_tests:
     runs-on: ubuntu-latest
-    container: precice/precice
     needs: [build]
     strategy:
       matrix:
@@ -37,8 +36,12 @@ jobs:
       - name: Install Julia
         uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.julia-version }}     
-        
+          version: ${{ matrix.julia-version }}  
+   
+      - uses: precice/setup-precice-action@testing
+        with:
+          precice-version: 'develop'
+
       - uses: actions/checkout@v2
 
       - name: Build Package

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
    
       - uses: precice/setup-precice-action@testing # needs to be changed to main after merge
         with:
-          precice-version: 'v2.5.0' # needs to be changed to develop
+          precice-version: 'develop'
 
       - uses: actions/checkout@v3
 
@@ -53,24 +53,6 @@ jobs:
         run: |
           cd test
           make
-          echo $PATH
-          echo $GITHUB_WORKSPACE
-          echo $LD_LIBRARY_PATH
-
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: Test Logs
-          path: /home/runner/
-          retention-days: 1
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1
-
-
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: Test Logs
-          path: /home/runner/
-          retention-days: 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}     
        
-      - uses: precice/setup-precice-action@v0
+      - uses: precice/setup-precice-action@main
         with:
           precice-version: 'develop'
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           precice-version: 'develop'
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,6 +52,9 @@ jobs:
         run: |
           cd test
           make
+          echo $PATH
+          echo $GITHUB_WORKSPACE
+          echo $LD_LIBRARY_PATH
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,14 +56,12 @@ jobs:
           echo $PATH
           echo $GITHUB_WORKSPACE
           echo $LD_LIBRARY_PATH
-          ls /home/runner/work/PreCICE.jl/PreCICE.jl/precice/lib
-          ls /home/runner/work/PreCICE.jl/PreCICE.jl/precice/
 
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: Test Logs
-          path: /home/runner/work/PreCICE.jl/PreCICE.jl/
+          path: /home/runner/
           retention-days: 1
 
       - name: Run tests
@@ -74,5 +72,5 @@ jobs:
         if: failure()
         with:
           name: Test Logs
-          path: /home/runner/work/PreCICE.jl/PreCICE.jl/
+          path: /home/runner/
           retention-days: 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,20 +50,15 @@ jobs:
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1
 
-      - name: Build fake Solverinterface and add /usr/local/lib to LD_LIBRARY_PATH
+      - name: Build fake Solverinterface
         run: |
           cd test
           make
+
+      - name: Add libprecice to LD_LIBRARY_PATH and adjust LD_PRELOAD
+        run: |
           echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo $LD_LIBRARY_PATH
-          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
-          echo $LIBRARY_PATH
-          echo $PATH
-          ls /usr/local/lib | grep libprecice
-          julia -e 'println(Libc.Libdl.DL_LOAD_PATH); println(Libc.Libdl.dlopen("libprecice"))'
-          ldconfig -p | grep libprecice
-          find /lib* /usr/lib* -name 'libprecice.so*'
-          
+          echo "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6" >> $GITHUB_ENV
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,5 +59,20 @@ jobs:
           ls /home/runner/work/PreCICE.jl/PreCICE.jl/precice/lib
           ls /home/runner/work/PreCICE.jl/PreCICE.jl/precice/
 
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Test Logs
+          path: /home/runner/work/PreCICE.jl/PreCICE.jl/
+          retention-days: 1
+
       - name: Run tests
         uses: julia-actions/julia-runtest@v1
+
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Test Logs
+          path: /home/runner/work/PreCICE.jl/PreCICE.jl/
+          retention-days: 1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,24 +14,11 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}     
-        
-      - uses: actions/setup-python@v1
-      - name: Install OpenMPI, CMake, Boost library, Eigen and pkg-config
-        run: |
-          sudo apt-get -yy update
-          sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev libeigen3-dev pkg-config
-          sudo rm -rf /var/lib/apt/lists/*
+       
+      - uses: precice/setup-precice-action
+        with:
+          precice-version: 'develop'
 
-      - name: Checkout precice
-        run: |
-          git clone https://github.com/precice/precice.git precice
-          cd precice
-          mkdir build && cd build
-          cmake .. -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DBUILD_TESTING=OFF
-          make -j $(nproc)
-          export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
-          cd
-      
       - uses: actions/checkout@v2
 
       - name: Build Package

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,6 @@ on: # run on every push to main and develop, and on every pull request to main a
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: precice/precice:develop
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +57,8 @@ jobs:
           echo $LD_LIBRARY_PATH
           echo $LIBRARY_PATH
           echo $PATH
+          ls /usr/local
+          julia -e 'println(Libc.Libdl.DL_LOAD_PATH); println(Libc.Libdl.dlopen("libprecice"))'
           ldconfig -p | grep libprecice
           find /lib* /usr/lib* -name 'libprecice.so*'
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,7 +57,7 @@ jobs:
           echo $LD_LIBRARY_PATH
           echo $LIBRARY_PATH
           echo $PATH
-          ls /usr/local
+          ls /usr/local/lib | grep libprecice
           julia -e 'println(Libc.Libdl.DL_LOAD_PATH); println(Libc.Libdl.dlopen("libprecice"))'
           ldconfig -p | grep libprecice
           find /lib* /usr/lib* -name 'libprecice.so*'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}     
        
-      - uses: precice/setup-precice-action@main
+      - uses: precice/setup-precice-action@testing
         with:
           precice-version: 'develop'
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,9 +34,9 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}  
    
-      - uses: precice/setup-precice-action@testing
+      - uses: precice/setup-precice-action@testing # needs to be changed to main after merge
         with:
-          precice-version: 'main'
+          precice-version: 'v2.5.0' # needs to be changed to develop
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev libeigen3-dev pkg-config
           sudo rm -rf /var/lib/apt/lists/*
 
-      - name: Checkout precice and make required files discoverable
+      - name: Checkout precice
         run: |
           git clone https://github.com/precice/precice.git precice
           cd precice
@@ -36,9 +36,6 @@ jobs:
 
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1
-
-      - name: Test Installation
-        run:  julia -e "using PreCICE; println(PreCICE.getVersionInformation())" 
 
   run_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
    
       - uses: precice/setup-precice-action@testing
         with:
-          precice-version: 'develop'
+          precice-version: 'main'
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,10 +14,6 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}     
-       
-      # - uses: precice/setup-precice-action@testing
-      #   with:
-      #     precice-version: 'develop'
 
       - uses: actions/checkout@v2
 
@@ -49,8 +45,8 @@ jobs:
 
       - name: install make
         run: |
-         apt update
-         apt install make
+         sudo apt update
+         sudo apt install make
 
       - name: Build fake Solverinterface
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,17 +50,20 @@ jobs:
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1
 
-      - name: Build fake Solverinterface
+      - name: Build fake Solverinterface and add /usr/local/lib to LD_LIBRARY_PATH
         run: |
           cd test
           make
+          echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
           echo $LD_LIBRARY_PATH
+          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
           echo $LIBRARY_PATH
           echo $PATH
           ls /usr/local/lib | grep libprecice
           julia -e 'println(Libc.Libdl.DL_LOAD_PATH); println(Libc.Libdl.dlopen("libprecice"))'
           ldconfig -p | grep libprecice
           find /lib* /usr/lib* -name 'libprecice.so*'
+          
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,13 @@
 name: Run Tests
-on: [push,pull_request]
+on: # run on every push to main and develop, and on every pull request to main and develop
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
 
 jobs:
   build:
@@ -25,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     strategy:
+      fail-fast: false
       matrix:
         julia-version: ['1.6.0','1.6.5','1.7.0','^1.7']
         julia-arch: [x64, x86]

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.6.0','1.6.5','1.7.0','^1.7']
+        julia-version: ['1.6.7','1.7','^1.8']
         julia-arch: [x64, x86]
     
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}     
        
-      - uses: precice/setup-precice-action
+      - uses: precice/setup-precice-action@v0
         with:
           precice-version: 'develop'
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,6 +12,7 @@ on: # run on every push to main and develop, and on every pull request to main a
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: precice/precice:develop
     strategy:
       fail-fast: false
       matrix:
@@ -31,6 +32,7 @@ jobs:
 
   run_tests:
     runs-on: ubuntu-latest
+    container: precice/precice:develop
     needs: [build]
     strategy:
       fail-fast: false
@@ -44,10 +46,6 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}  
    
-      - uses: precice/setup-precice-action@testing # needs to be changed to main after merge
-        with:
-          precice-version: 'develop'
-
       - uses: actions/checkout@v3
 
       - name: Build Package

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
          apt update
          apt install make
 
-      - name: Build Fake Solverinterface
+      - name: Build fake Solverinterface
         run: |
           cd test
           make

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,6 +58,8 @@ jobs:
           echo $LD_LIBRARY_PATH
           echo $LIBRARY_PATH
           echo $PATH
+          ldconfig -p | grep libprecice
+          find /lib* /usr/lib* -name 'libprecice.so*'
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,11 +51,6 @@ jobs:
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1
 
-      - name: install make
-        run: |
-         sudo apt update
-         sudo apt install make
-
       - name: Build fake Solverinterface
         run: |
           cd test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,6 +5,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         julia-version: ['1.6.0','1.6.5','1.7.0','^1.7']
         julia-arch: [x64, x86]
@@ -55,6 +56,8 @@ jobs:
           echo $PATH
           echo $GITHUB_WORKSPACE
           echo $LD_LIBRARY_PATH
+          ls /home/runner/work/PreCICE.jl/PreCICE.jl/precice/lib
+          ls /home/runner/work/PreCICE.jl/PreCICE.jl/precice/
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,6 +55,9 @@ jobs:
         run: |
           cd test
           make
+          echo $LD_LIBRARY_PATH
+          echo $LIBRARY_PATH
+          echo $PATH
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,6 @@ on: [push,pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: precice/precice
     strategy:
       matrix:
         julia-version: ['1.6.0','1.6.5','1.7.0','^1.7']
@@ -16,10 +15,30 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}     
         
+      - uses: actions/setup-python@v1
+      - name: Install OpenMPI, CMake, Boost library, Eigen and pkg-config
+        run: |
+          sudo apt-get -yy update
+          sudo apt-get install -y libopenmpi-dev cmake libboost-all-dev libeigen3-dev pkg-config
+          sudo rm -rf /var/lib/apt/lists/*
+
+      - name: Checkout precice and make required files discoverable
+        run: |
+          git clone https://github.com/precice/precice.git precice
+          cd precice
+          mkdir build && cd build
+          cmake .. -DPRECICE_MPICommunication=OFF -DPRECICE_PETScMapping=OFF -DPRECICE_PythonActions=OFF -DBUILD_TESTING=OFF
+          make -j $(nproc)
+          export LD_LIBRARY_PATH=$PWD:$LD_LIBRARY_PATH
+          cd
+      
       - uses: actions/checkout@v2
 
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1
+
+      - name: Test Installation
+        run:  julia -e "using PreCICE; println(PreCICE.getVersionInformation())" 
 
   run_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Add libprecice to LD_LIBRARY_PATH and adjust LD_PRELOAD
         run: |
           echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6" >> $GITHUB_ENV
+          echo "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6:/usr/lib/x86_64-linux-gnu/libcurl.so.4" >> $GITHUB_ENV
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1

--- a/test/DummySolverInterface.c
+++ b/test/DummySolverInterface.c
@@ -90,8 +90,10 @@ double precicec_advance(double computedTimestepLength)
     return -1;
 }
 
-void precicec_precicec_finalize()
+void precicec_finalize()
 {
+    // print some output to check if the library is called
+    printf("Finalizing solver interface");
 }
 
 int precicec_getDimensions()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,7 @@ push!(Libc.Libdl.DL_LOAD_PATH, dirname(abspath(PROGRAM_FILE)))
 
     @testset "Solverdummies" begin
         include("test_solverdummy.jl")
+        println(test_solverdummy())
         @test isnothing(test_solverdummy())
     end
 


### PR DESCRIPTION
This PR modifies the tests to build precice develop instead of using the latest precice docker container as discussed in #47. 