### PR TITLE
Leftover API changes which were missed in the v3.0.0 release

### DIFF
--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -874,9 +874,7 @@ single mesh (from the other participant) is now involved in this situation since
 mesh defined by the participant itself is not required any more. In order to re-partition the
 received mesh, the participant needs to define the mesh region it wants read data from and
 write data to. The mesh region is specified through an axis-aligned bounding box given by the
-lower and upper [min and max] bounding-box limits in each space dimension [x, y, z]. This function is still
-experimental
-
+lower and upper [min and max] bounding-box limits in each space dimension [x, y, z].
 
 # Arguments
 - `meshName::String`: Name of the mesh to define the access region for.
@@ -920,7 +918,7 @@ end
     getMeshVertexIDsAndCoordinates(meshName::String)::Tuple{AbstractArray{Integer}, AbstractArray{Float64}}
 
 Iterating over the region of interest defined by bounding boxes and reading the corresponding
-coordinates omitting the mapping. This function is still experimental.
+coordinates omitting the mapping.
 
 # Arguments
 - `meshName::String`: Name of the mesh to get the vertices and IDs for.

--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -48,7 +48,7 @@ export
     setMeshTetrahedron,
     setMeshTetrahedra,
     setMeshAccessRegion,
-    getMeshVerticesAndIDs,
+    getMeshVertexIDsAndCoordinates,
 
     # data access
     writeData,
@@ -919,7 +919,7 @@ end
 
 @doc """
 
-    getMeshVerticesAndIDs(meshName::String)::Tuple{AbstractArray{Integer}, AbstractArray{Float64}}
+    getMeshVertexIDsAndCoordinates(meshName::String)::Tuple{AbstractArray{Integer}, AbstractArray{Float64}}
 
 Iterating over the region of interest defined by bounding boxes and reading the corresponding
 coordinates omitting the mapping. This function is still experimental.
@@ -931,16 +931,16 @@ coordinates omitting the mapping. This function is still experimental.
 - `vertexIDs::AbstractArray{Integer}`: IDs of the vertices.
 - `vertexCoordinates::AbstractArray{Float64}`: Coordinates of the vertices and corresponding data values. Shape [N x D] where N = number of vertices and D = number of data dimensions.
 """
-function getMeshVerticesAndIDs(
+function getMeshVertexIDsAndCoordinates(
     meshName::String,
 )::Tuple{AbstractArray{Integer},AbstractArray{Float64}}
-    @warn "The function getMeshVerticesAndIDs is still experimental"
+    @warn "The function getMeshVertexIDsAndCoordinates is still experimental"
 
     _size = getMeshVertexSize(meshName)
     vertexIDs = zeros(Cint, _size)
     vertexCoordinates = zeros(Float64, _size * getMeshDimensions(meshName))
     ccall(
-        (:precicec_getMeshVerticesAndIDs, "libprecice"),
+        (:precicec_getMeshVertexIDsAndCoordinates, "libprecice"),
         Cvoid,
         (Ptr{Int8}, Cint, Ref{Cint}, Ref{Cdouble}),
         meshName,

--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -944,8 +944,7 @@ function getMeshVertexIDsAndCoordinates(
         vertexIDs,
         vertexCoordinates,
     )
-    return vertexIDs,
-    permutedims(reshape(vertexCoordinates, (_size, getMeshDimensions(meshName))))
+    return vertexIDs, reshape(vertexCoordinates, (_size, getMeshDimensions(meshName)))
 end
 
 @doc """

--- a/src/PreCICE.jl
+++ b/src/PreCICE.jl
@@ -904,8 +904,6 @@ the safety factor region resulting from the mapping. The default value of the sa
 enlarged.
 """
 function setMeshAccessRegion(meshName::String, boundingBox::AbstractArray{Float64})
-    @warn "The function setMeshAccessRegion is still experimental"
-
     @assert length(boundingBox) > 0 "The bounding box must not be empty"
     @assert length(boundingBox) == getMeshDimensions(meshName) * 2 "The bounding box must have the same dimension as the mesh"
     ccall(
@@ -934,8 +932,6 @@ coordinates omitting the mapping. This function is still experimental.
 function getMeshVertexIDsAndCoordinates(
     meshName::String,
 )::Tuple{AbstractArray{Integer},AbstractArray{Float64}}
-    @warn "The function getMeshVertexIDsAndCoordinates is still experimental"
-
     _size = getMeshVertexSize(meshName)
     vertexIDs = zeros(Cint, _size)
     vertexCoordinates = zeros(Float64, _size * getMeshDimensions(meshName))

--- a/test/DummyParticipant.c
+++ b/test/DummyParticipant.c
@@ -250,8 +250,8 @@ void precicec_getMeshVertexIDsAndCoordinates(const char *meshName, const int siz
     for (int i = 0; i < size; i++)
     {
         ids[i] = fake_ids[i];
-        coordinates[fake_mesh_dimensions * i] = i;
-        coordinates[fake_mesh_dimensions * i + 1] = i + n_fake_vertices;
-        coordinates[fake_mesh_dimensions * i + 2] = i + 2 * n_fake_vertices;
+        coordinates[fake_mesh_dimensions * i] = fake_mesh_dimensions * i;
+        coordinates[fake_mesh_dimensions * i + 1] = fake_mesh_dimensions * i + 1;
+        coordinates[fake_mesh_dimensions * i + 2] = fake_mesh_dimensions * i + 2;
     }
 }

--- a/test/DummyParticipant.c
+++ b/test/DummyParticipant.c
@@ -243,7 +243,7 @@ void precicec_setMeshAccessRegion(const char *meshName, const double *boundingBo
     }
 }
 
-void precicec_getMeshVerticesAndIDs(const char *meshName, const int size, int *ids, double *coordinates)
+void precicec_getMeshVertexIDsAndCoordinates(const char *meshName, const int size, int *ids, double *coordinates)
 {
     assert(size == n_fake_vertices);
     assert(strcmp(meshName, "FakeMesh") == 0);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,7 +49,7 @@ push!(Libc.Libdl.DL_LOAD_PATH, dirname(abspath(PROGRAM_FILE)))
             @test writeGradientData()
             @test getVersionInformation()
             @test setMeshAccessRegion()
-            @test getMeshVerticesAndIDs()
+            @test getMeshVertexIDsAndCoordinates()
         end #if
     end # testset
 

--- a/test/test_functioncalls.jl
+++ b/test/test_functioncalls.jl
@@ -185,7 +185,7 @@ function getMeshVertexIDsAndCoordinates()
     nFakeVertices = 3 # compare to test/DummyParticipant.c, fake_n_vertices
     vertexIDs = Cint[0, 1, 2]
     expected_vertices =
-        reshape(0:(nFakeVertices*fakeMeshDimension-1), (nFakeVertices, fakeMeshDimension))
+        reshape(0.0:(nFakeVertices*fakeMeshDimension-1), (nFakeVertices, fakeMeshDimension))
     fakeIDs, fakeVertices = PreCICE.getMeshVertexIDsAndCoordinates(fakeMeshName)
     return fakeIDs == vertexIDs && fakeVertices == expected_vertices
 end

--- a/test/test_functioncalls.jl
+++ b/test/test_functioncalls.jl
@@ -178,7 +178,7 @@ function setMeshAccessRegion()
     return true
 end
 
-function getMeshVerticesAndIDs()
+function getMeshVertexIDsAndCoordinates()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
     fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
     fakeMeshDimension = 3  # compare to test/Participant.c, fake_dimensions
@@ -186,6 +186,6 @@ function getMeshVerticesAndIDs()
     vertexIDs = Cint[0, 1, 2]
     expected_vertices =
         reshape(0:(nFakeVertices*fakeMeshDimension-1), (nFakeVertices, fakeMeshDimension))
-    fakeIDs, fakeVertices = PreCICE.getMeshVerticesAndIDs(fakeMeshName)
+    fakeIDs, fakeVertices = PreCICE.getMeshVertexIDsAndCoordinates(fakeMeshName)
     return fakeIDs == vertexIDs && fakeVertices == expected_vertices
 end

--- a/test/test_functioncalls.jl
+++ b/test/test_functioncalls.jl
@@ -13,16 +13,16 @@ end
 
 function getMeshDimensions()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshDimension = 3  # compare to test/Participant.c, fake_dimensions
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
+    fakeMeshDimension = 3  # compare to test/DummyParticipant.c, fake_dimensions
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
     return fakeMeshDimension == PreCICE.getMeshDimensions(fakeMeshName)
 end
 
 function getDataDimensions()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-    fakeDataName = "FakeData"  # compare to test/Participant.c, fake_data_name
-    fakeDataDimension = 3  # compare to test/Participant.c, fake_dimensions
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+    fakeDataName = "FakeData"  # compare to test/DummyParticipant.c, fake_data_name
+    fakeDataDimension = 3  # compare to test/DummyParticipant.c, fake_dimensions
     return fakeDataDimension == PreCICE.getDataDimensions(fakeMeshName, fakeDataName)
 end
 
@@ -58,27 +58,27 @@ end
 
 function hasMesh()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
     return false == PreCICE.hasMesh(fakeMeshName)
 end
 
 function hasData()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-    fakeDataName = "FakeData"  # compare to test/Participant.c, fake_data_name
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+    fakeDataName = "FakeData"  # compare to test/DummyParticipant.c, fake_data_name
     return false == PreCICE.hasData(fakeMeshName, fakeDataName)
 end
 
 function requiresMeshConnectivityFor()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
     return false == PreCICE.requiresMeshConnectivityFor(fakeMeshName)
 end
 
 function setMeshVertex()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-    fakeMeshDimension = 3  # compare to test/Participant.c, fake_dimensions
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+    fakeMeshDimension = 3  # compare to test/DummyParticipant.c, fake_dimensions
     fakePosition = rand(Cdouble, fakeMeshDimension)
     fakeVertexId = PreCICE.setMeshVertex(fakeMeshName, fakePosition)
     return 0 == fakeVertexId
@@ -87,9 +87,9 @@ end
 
 function setMeshVertices()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-    fakeMeshDimension = 3  # compare to test/Participant.c, fake_dimensions
-    nFakeVertices = 3  # compare to test/Participant.c, n_fake_vertices
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+    fakeMeshDimension = 3  # compare to test/DummyParticipant.c, fake_dimensions
+    nFakeVertices = 3  # compare to test/DummyParticipant.c, n_fake_vertices
     positions = rand(Cdouble, (nFakeVertices, fakeMeshDimension))
     expectedOutput = 0:(nFakeVertices-1)
     actualOutput = PreCICE.setMeshVertices(fakeMeshName, positions)
@@ -98,9 +98,9 @@ end
 
 # function setMeshVerticesEmpty()
 #     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-#     fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-#     fakeMeshDimension = 3  # compare to test/Participant.c, fake_dimensions
-#     nFakeVertices = 0  # compare to test/Participant.c, n_fake_vertices
+#     fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+#     fakeMeshDimension = 3  # compare to test/DummyParticipant.c, fake_dimensions
+#     nFakeVertices = 0  # compare to test/DummyParticipant.c, n_fake_vertices
 #     positions = rand(Cdouble, (nFakeVertices, fakeMeshDimension))
 #     expectedOutput = []
 #     actualOutput = PreCICE.setMeshVertices(fakeMeshName, positions)
@@ -109,8 +109,8 @@ end
 
 function getMeshVertexSize()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-    nFakeVertices = 3  # compare to test/Participant.c, n_fake_vertices
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+    nFakeVertices = 3  # compare to test/DummyParticipant.c, n_fake_vertices
     nVertices = PreCICE.getMeshVertexSize(fakeMeshName)
     return nFakeVertices == nVertices
 end
@@ -126,8 +126,8 @@ end
 
 function readWriteData()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-    fakeDataName = "FakeData"  # compare to test/Participant.c, fake_data_name
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+    fakeDataName = "FakeData"  # compare to test/DummyParticipant.c, fake_data_name
     writeData = [3.0 7.0 8.0; 7.0 6.0 5.0]
     PreCICE.writeData(fakeMeshName, fakeDataName, Cint[1, 2], writeData)
     readData = PreCICE.readData(fakeMeshName, fakeDataName, Cint[1, 2], 1.0)
@@ -144,16 +144,16 @@ end
 
 function requiresGradientDataFor()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-    fakeDataName = "FakeData"  # compare to test/Participant.c, fake_data_name
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+    fakeDataName = "FakeData"  # compare to test/DummyParticipant.c, fake_data_name
     return false == PreCICE.requiresGradientDataFor(fakeMeshName, fakeDataName)
 
 end
 
 function writeGradientData()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-    fakeDataName = "FakeData"  # compare to test/Participant.c, fake_data_name
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+    fakeDataName = "FakeData"  # compare to test/DummyParticipant.c, fake_data_name
     nVertices = 2
     ndims = 3
     gradientData = rand(nVertices, ndims * ndims)
@@ -166,13 +166,13 @@ end
 
 function getVersionInformation()
     versionInfo = PreCICE.getVersionInformation()
-    fakeVersionInfo = "dummy"  # compare to test/Participant.c
+    fakeVersionInfo = "dummy"  # compare to test/DummyParticipant.c
     return versionInfo == fakeVersionInfo
 end
 
 function setMeshAccessRegion()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
     fakeBoundingBox = [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
     PreCICE.setMeshAccessRegion(fakeMeshName, fakeBoundingBox)
     return true
@@ -180,9 +180,9 @@ end
 
 function getMeshVertexIDsAndCoordinates()
     PreCICE.createParticipant("test", "dummy.xml", 0, 1)
-    fakeMeshName = "FakeMesh"  # compare to test/Participant.c, fake_mesh_name
-    fakeMeshDimension = 3  # compare to test/Participant.c, fake_dimensions
-    nFakeVertices = 3 # compare to test/Participant.c, fake_n_vertices
+    fakeMeshName = "FakeMesh"  # compare to test/DummyParticipant.c, fake_mesh_name
+    fakeMeshDimension = 3  # compare to test/DummyParticipant.c, fake_dimensions
+    nFakeVertices = 3 # compare to test/DummyParticipant.c, fake_n_vertices
     vertexIDs = Cint[0, 1, 2]
     expected_vertices =
         reshape(0:(nFakeVertices*fakeMeshDimension-1), (nFakeVertices, fakeMeshDimension))


### PR DESCRIPTION
The following updates were not done in the v3.0.0 release and are not done:

* The old API function `getMeshVerticesAndIDs` needs to be updated to `getMeshVertexIDsAndCoorindates`.
* Some other minor updates are also included in the same PR.