### PR TITLE
Release v3.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PreCICE"
 uuid = "57fbd4af-5cc3-4712-aac0-6930e7658184"
 authors = ["preCICE <https://precice.org/> and contributors"]
-version = "3.0.1"
+version = "3.1.1"
 
 [compat]
 julia = "1.10"


### PR DESCRIPTION
Compatibility release for preCICE [v3.1.0](https://github.com/precice/precice/releases/tag/v3.1.0)