### PR TITLE
Release v3.4.0

### DIFF
--- a/.github/workflows/TestJuliaVersions.yml
+++ b/.github/workflows/TestJuliaVersions.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Cache preCICE
         id: cache-libprecice
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: libprecice3_3.3.0_noble.deb
           key: libprecice3_3.3.0_noble.deb1

--- a/.github/workflows/TestJuliaVersions.yml
+++ b/.github/workflows/TestJuliaVersions.yml
@@ -21,7 +21,7 @@ jobs:
         uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}         
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         
 
       - name: Cache preCICE

--- a/.github/workflows/TestJuliaVersions.yml
+++ b/.github/workflows/TestJuliaVersions.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-noble]
-        julia-version: ['1.10.0', 'nightly']
+        julia-version: ["1", "nightly"]
 
     steps:
       - name: Update System
@@ -28,16 +28,16 @@ jobs:
         id: cache-libprecice
         uses: actions/cache@v5
         with:
-          path: libprecice3_3.3.0_noble.deb
-          key: libprecice3_3.3.0_noble.deb1
-          restore-keys: libprecice3_3.3.0_noble.deb1
+          path: libprecice3_3.4.0_noble.deb
+          key: libprecice3_3.4.0_noble.deb1
+          restore-keys: libprecice3_3.4.0_noble.deb1
       
       - name: Download preCICE
         if: steps.cache-libprecice.outputs.cache-hit != 'true'
-        run: wget https://github.com/precice/precice/releases/download/v3.3.0/libprecice3_3.3.0_noble.deb
+        run: wget https://github.com/precice/precice/releases/download/v3.4.0/libprecice3_3.4.0_noble.deb
 
       - name: Install preCICE
-        run: sudo apt install ./libprecice3_3.3.0_noble.deb
+        run: sudo apt install ./libprecice3_3.4.0_noble.deb
 
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1
@@ -45,7 +45,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Build Package
         uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ["1.8.0", "1.9.0", "1.10.0"]
+        julia-version: ["1", "lts", "pre"]
         julia-arch: [x64, x86]
 
     steps:
       - name: Install Julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
 
@@ -36,12 +36,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ["1.8.0", "1.9.0", "1.10.0"]
+        julia-version: ["1", "lts", "pre"]
         julia-arch: [x64, x86]
 
     steps:
       - name: Install Julia
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
 
@@ -58,7 +58,7 @@ jobs:
       - name: Add libprecice to LD_LIBRARY_PATH and adjust LD_PRELOAD
         run: |
           echo "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-          echo "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6:/usr/lib/x86_64-linux-gnu/libcurl.so.4" >> $GITHUB_ENV
+          echo "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libstdc++.so.6" >> $GITHUB_ENV
 
       - name: Run tests
         uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
 
   run_tests:
     runs-on: ubuntu-latest
-    container: precice/precice:develop
+    container: precice/precice:nightly
     needs: [build]
     strategy:
       fail-fast: false

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install JuliaFormatter and format
         # This will use the latest version by default but you can set the version like so:
         #

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PreCICE"
 uuid = "57fbd4af-5cc3-4712-aac0-6930e7658184"
 authors = ["preCICE <https://precice.org/> and contributors"]
-version = "3.3.0"
+version = "3.4.0"
 
 [compat]
 julia = "1.10"

--- a/README.md
+++ b/README.md
@@ -156,6 +156,6 @@ This package works with official Julia binaries listed below. See the [Platform 
 
 ## Supported versions
 
-The package is actively tested for Julia versions `1.8.0`, `1.9.0`, and `1.10.0`. Julia versions prior to `1.6.0` are not supported.
+In the CI, we test the package for the latest `v1`, the latest LTS, and the latest prerelease versions of Julia.
 
 [Unofficial Julia binaries](https://julialang.org/downloads/platform/#platform_specific_instructions_for_unofficial_binaries) may not be compatible.


### PR DESCRIPTION
This release is required due to the preCICE release [v3.4.0](https://github.com/precice/precice/releases/tag/v3.4.0)